### PR TITLE
[issue-17] Add console log reporting in AbstractWebElement

### DIFF
--- a/environment/pom.xml
+++ b/environment/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>scaffold</artifactId>
         <groupId>com.retailmenot.scaffold</groupId>
-        <version>1.0.0-beta</version>
+        <version>1.1.0-beta-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.retailmenot.scaffold</groupId>
         <artifactId>scaffold</artifactId>
-        <version>1.0.0-beta</version>
+        <version>1.1.0-beta-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework/src/test/java/com/retailmenot/scaffold/BaseUnitTest.java
+++ b/framework/src/test/java/com/retailmenot/scaffold/BaseUnitTest.java
@@ -1,7 +1,8 @@
 package com.retailmenot.scaffold;
 
-import com.retailmenot.scaffold.environment.config.ScaffoldConfiguration;
 import com.retailmenot.scaffold.environment.config.DesiredCapabilitiesConfigurationProperties;
+import com.retailmenot.scaffold.environment.config.ScaffoldConfiguration;
+import com.retailmenot.scaffold.models.unittests.MockLogs;
 import com.retailmenot.scaffold.models.unittests.MockWebDriver;
 import com.retailmenot.scaffold.models.unittests.MockWebElement;
 import com.retailmenot.scaffold.webdriver.TestContext;
@@ -16,10 +17,16 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.logging.LogEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
 
 import static com.retailmenot.scaffold.util.AutomationUtils.getUniqueString;
 
@@ -36,6 +43,9 @@ public abstract class BaseUnitTest {
     protected static final String TAG_NAME_2 = "test element 2";
     protected static final String TEXT_NAME_1 = "element 1";
     protected static final String TEXT_NAME_2 = "element 2";
+    protected static final Level LOG_LEVEL = Level.SEVERE;
+    protected static final long TIME_STAMP = new Date().getTime();
+    protected static final String MESSAGE = "Mock Log Entry";
     private static String MOCK_UNIT_TEST;
 
     protected WebDriverManager webDriverContextImpl;
@@ -44,6 +54,7 @@ public abstract class BaseUnitTest {
     protected TestableAbstractWebElement testAbstractWebElement;
     protected MockWebElement mockElement1;
     protected MockWebElement mockElement2;
+    protected MockLogs mockLogs = new MockLogs();
 
     @Autowired
     protected RestTemplate seleniumGridRestTemplate;
@@ -95,6 +106,11 @@ public abstract class BaseUnitTest {
         mockElement2 = new MockWebElement()
                 .text(TEXT_NAME_2)
                 .tagName(TAG_NAME_2);
+
+        // Create a new error log entry
+        List<LogEntry> logEntryList = new ArrayList<>();
+        logEntryList.add(new LogEntry(LOG_LEVEL, TIME_STAMP, MESSAGE));
+        mockLogs.set(logEntryList);
     }
 
     /**

--- a/framework/src/test/java/com/retailmenot/scaffold/webelement/AbstractWebElementTests.java
+++ b/framework/src/test/java/com/retailmenot/scaffold/webelement/AbstractWebElementTests.java
@@ -1,6 +1,8 @@
 package com.retailmenot.scaffold.webelement;
 
 import com.retailmenot.scaffold.BaseUnitTest;
+import com.retailmenot.scaffold.models.unittests.MockLogs;
+import com.retailmenot.scaffold.models.unittests.MockWebDriver;
 import com.retailmenot.scaffold.models.unittests.MockWebElement;
 import com.retailmenot.scaffold.util.AutomationUtils;
 import com.retailmenot.scaffold.webelements.DivWebElement;
@@ -8,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -136,6 +140,23 @@ public class AbstractWebElementTests extends BaseUnitTest {
     @Test
     public void testExistsFalse() {
         assertFalse("The element should not exist", testAbstractWebElement.exists());
+    }
+
+    /**
+     * Test the mock log error created from {@link MockLogs}
+     *
+     * This test does not utilized the retrieval of logs from the {@link MockWebDriver} and instead tests only the creation
+     * and usage of an independent {@link MockLogs} object.
+     */
+    @Test
+    public void testGetErrorLog() {
+        // Get the entries and ensure they are correct
+        var mockBrowserLogs = mockLogs.get(LogType.BROWSER);
+        for (LogEntry entry : mockBrowserLogs) {
+            assertEquals(LOG_LEVEL, entry.getLevel());
+            assertEquals(TIME_STAMP, entry.getTimestamp());
+            assertEquals(MESSAGE, entry.getMessage());
+        }
     }
 
     @Test

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.retailmenot.scaffold</groupId>
         <artifactId>scaffold</artifactId>
-        <version>1.0.0-beta</version>
+        <version>1.1.0-beta-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockLogs.java
+++ b/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockLogs.java
@@ -1,0 +1,32 @@
+package com.retailmenot.scaffold.models.unittests;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.Beta;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.Logs;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Beta
+@Slf4j
+public class MockLogs implements Logs {
+
+    private LogEntries logEntries;
+
+    @Override
+    public LogEntries get(String logType) {
+        return logEntries;
+    }
+
+    @Override
+    public Set<String> getAvailableLogTypes() {
+        return Collections.emptySet();
+    }
+
+    public void set(List<LogEntry> logEntryList) {
+        logEntries = new LogEntries(logEntryList);
+    }
+}

--- a/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockOptions.java
+++ b/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockOptions.java
@@ -80,6 +80,6 @@ public class MockOptions implements Options {
     @Override
     @Beta
     public Logs logs() {
-        return null;
+        return new MockLogs();
     }
 }

--- a/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockWebDriver.java
+++ b/models/src/main/java/com/retailmenot/scaffold/models/unittests/MockWebDriver.java
@@ -1,12 +1,19 @@
 package com.retailmenot.scaffold.models.unittests;
 
-import org.openqa.selenium.*;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class MockWebDriver implements WebDriver, JavascriptExecutor {
+@Slf4j
+public class MockWebDriver extends RemoteWebDriver implements WebDriver, JavascriptExecutor {
 
     private WebElement elementToFind;
     private List<WebElement> elementsToFind;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <url>https://github.com/RetailMeNot/scaffold</url>
     <groupId>com.retailmenot.scaffold</groupId>
     <artifactId>scaffold</artifactId>
-    <version>1.0.0-beta</version>
+    <version>1.1.0-beta-SNAPSHOT</version>
     <modules>
         <module>environment</module>
         <module>framework</module>


### PR DESCRIPTION
* Updated the `AbstractWebElement` to simply provide any `LogEntries` through lombok's `log.error`level upon a `NoSuchElementException` when interacting with elements.
* Updated the pom versions to SNAPSHOTS. Before we make another release, we'll have the gitlab build handle the versioning.
* Added a `MockLogs` object to return a dummy `LogEntry` of `(Severe, 1000L, "Mock log entry")`. This was necessary to test the new console log report of `AbstractWebElement`. Prior to this update, the `Logs` object returned null.