### PR TITLE
fix: add ios to the platform enum #6

### DIFF
--- a/models/src/main/java/com/retailmenot/scaffold/models/enums/Platform.java
+++ b/models/src/main/java/com/retailmenot/scaffold/models/enums/Platform.java
@@ -11,7 +11,8 @@ public enum Platform {
     Mac("MAC"),
     Linux("LINUX"),
     Unix("UNIX"),
-    Android("ANDROID");
+    Android("ANDROID"),
+    iOS("IOS");
 
     private final String platform;
 


### PR DESCRIPTION
PR for #6 

This is primarily for testing to ensure the semver tags are working now so we can get an automated release.

* Added ios to the Platform enum